### PR TITLE
feature: 서버 로직 개선 및 OMS-MCI 로그인 구현

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Compiler and flags
 CC = gcc
 CFLAGS = -Iinclude -I$(NETWORK_DIR) -I. -Wall -Wextra -O2
-LDFLAGS =
+LDFLAGS = -lmysqlclient
 
 # Directories
 INCLUDE_DIR = include

--- a/include/env.h
+++ b/include/env.h
@@ -14,4 +14,9 @@
 #define MCI_SERVER_IP "127.0.0.1"
 #define MCI_SERVER_PORT 8081
 
+#define MYSQL_HOST "127.0.0.1"
+#define MYSQL_USER "root"
+#define MYSQL_PASSWORD "1234" 
+#define MYSQL_DBNAME "mydb"
+
 #endif

--- a/network/oms_network.c
+++ b/network/oms_network.c
@@ -8,11 +8,16 @@
 #include <arpa/inet.h>
 #include <sys/epoll.h>
 #include "oms_network.h"
+#include <mysql/mysql.h>
 #include "../include/common.h"
 
 #define BUFFER_SIZE 1024
+#define LOGIN_SUCCESS 200
+#define ID_NOT_FOUND 201
+#define PASSWORD_MISMATCH 202
+#define SERVER_ERROR 500
 
-void handle_oms(int oms_sock, int pipe_write, int pipe_read) {
+void handle_oms(MYSQL *conn, int oms_sock, int pipe_write, int pipe_read) {
     int epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
         perror("epoll_create1");
@@ -35,6 +40,8 @@ void handle_oms(int oms_sock, int pipe_write, int pipe_read) {
     }
 
     char buffer[BUFFER_SIZE];
+    size_t buffer_offset = 0;
+
     while (1) {
         int nfds = epoll_wait(epoll_fd, events, 2, -1);
         if (nfds == -1) {
@@ -44,66 +51,78 @@ void handle_oms(int oms_sock, int pipe_write, int pipe_read) {
 
         for (int i = 0; i < nfds; ++i) {
             ssize_t len = 0;
-            
-            if (events[i].data.fd == oms_sock) {
-                printf("event from oms\n");
-                len = recv(oms_sock, buffer, BUFFER_SIZE, 0);
 
-                if (len == 0) {  // 클라이언트 연결 종료: 리소스 정리
-                    printf("[OMS Server] Client disconnected\n");
-                    if (epoll_ctl(epoll_fd, EPOLL_CTL_DEL, oms_sock, NULL) == -1) {
-                        perror("epoll_ctl: EPOLL_CTL_DEL failed");
-                    }
+            if (events[i].data.fd == oms_sock) {
+                len = recv(oms_sock, buffer + buffer_offset, BUFFER_SIZE - buffer_offset, 0);
+                if (len == 0) {  // Client disconnected
+                    printf("[MCI Server] Client disconnected\n");
                     close(oms_sock);
-                    oms_sock = -1;  
+                    oms_sock = -1;
                     continue;
                 }
             } else if (events[i].data.fd == pipe_read) {
-                printf("event from pipe\n");
-                len = read(pipe_read, buffer, BUFFER_SIZE);
+                len = read(pipe_read, buffer + buffer_offset, BUFFER_SIZE - buffer_offset);
             } else {
-                printf("event from ?\n");
+                printf("[MCI Server] Unknown event source: fd = %d\n", events[i].data.fd);
+                continue;
             }
-            
-            if (len < 0) {  // 에러 처리
+
+            if (len < 0) {
                 perror("Read error");
                 continue;
             }
 
-            hdr *header = (hdr *)buffer;
-            void *body = buffer;
+            buffer_offset += len;
+            
+            // Process all complete messages in the buffer
+            size_t processed_bytes = 0;
+            while (processed_bytes + sizeof(hdr) <= buffer_offset) {
+                hdr *header = (hdr *)(buffer + processed_bytes);
 
-            if (events[i].data.fd == oms_sock) {
-                printf("[OMS -> OMS-MCI] event occurs\n");
-                switch (header->tr_id) {
-                    case OMQ_LOGIN: {
-                        handle_omq_login((omq_login *)body, oms_sock);
-                        break;
+                if (processed_bytes + header->length > buffer_offset) {
+                    break;  // Wait for more data
+                }
+
+                void *body = buffer + processed_bytes;
+
+                if (events[i].data.fd == oms_sock) {
+                    printf("[OMS -> OMS-MCI] event occurs\n");
+                    switch (header->tr_id) {
+                        case OMQ_LOGIN:
+                            handle_omq_login((omq_login *)body, oms_sock, conn);
+                            break;
+                        case OMQ_STOCK_INFOS:
+                            handle_omq_stocks((omq_stocks *)body, pipe_write);
+                            break;
+                        case OMQ_CURRENT_MARKET_PRICE:
+                            handle_omq_market_price((omq_market_price *)body, pipe_write);
+                            break;
+                        default:
+                            printf("[ERROR] Unknown TR_ID from OMS socket: %d\n", header->tr_id);
+                            break;
                     }
-                    case OMQ_STOCK_INFOS:
-                        handle_omq_stocks((omq_stocks *)body, pipe_write);
-                        break;
-                    case OMQ_CURRENT_MARKET_PRICE:
-                        handle_omq_market_price((omq_market_price *)body, pipe_write);
-                        break;
-                    default:
-                        printf("[ERROR] Unknown TR_ID from OMS socket: %d\n", header->tr_id);
-                        break;
+                } else if (events[i].data.fd == pipe_read) {
+                    printf("[OMS-KRX -> OMS-MCI] event occurs\n");
+                    switch (header->tr_id) {
+                        case MOT_STOCK_INFOS:
+                            handle_mot_stocks((mot_stocks *)body, oms_sock);
+                            break;
+                        case MOT_CURRENT_MARKET_PRICE:
+                            handle_mot_market_price((mot_market_price *)body, oms_sock);
+                            break;
+                        default:
+                            printf("[ERROR] Unknown TR_ID from pipe: %d\n", header->tr_id);
+                            break;
+                    }
                 }
-            } else if (events[i].data.fd == pipe_read) {
-                printf("[OMS-KRX -> OMS-MCI] event occurs\n");
-                switch (header->tr_id) {
-                    case MOT_STOCK_INFOS:
-                        handle_mot_stocks((mot_stocks *)body, oms_sock);
-                        break;
-                    case MOT_CURRENT_MARKET_PRICE:
-                        handle_mot_market_price((mot_market_price *)body, oms_sock);
-                        break;
-                    default:
-                        printf("[ERROR] Unknown TR_ID from pipe: %d\n", header->tr_id);
-                        break;
-                }
+                processed_bytes += header->length;
             }
+
+            // Shift unprocessed bytes to the beginning of the buffer
+            if (processed_bytes < buffer_offset) {
+                memmove(buffer, buffer + processed_bytes, buffer_offset - processed_bytes);
+            }
+            buffer_offset -= processed_bytes;
         }
     }
 
@@ -114,21 +133,13 @@ void handle_oms(int oms_sock, int pipe_write, int pipe_read) {
     exit(EXIT_SUCCESS);
 }
 
-void handle_omq_login(omq_login *data, int oms_sock) {
+
+void handle_omq_login(omq_login *data, int oms_sock, MYSQL *conn) {
     printf("[OMQ_LOGIN] User ID: %s, Password: %s\n", data->user_id, data->user_pw);
 
-    /*
-        TODO: DB 처리 하기 - Validate user credentials
-    */
+    int status_code = validate_user_credentials(conn, data->user_id, data->user_pw);
 
-    mot_login response;
-    response.hdr.tr_id = MOT_LOGIN;
-    response.hdr.length = sizeof(mot_login);
-    response.status_code = 200;
-
-    if (send(oms_sock, &response, sizeof(response), 0) == -1) {
-        perror("[OMQ_LOGIN] Failed to send response to OMS");
-    }
+    send_login_response(oms_sock, status_code);
 }
 
 void handle_omq_stocks(omq_stocks *data, int pipe_write) {
@@ -161,4 +172,50 @@ void handle_mot_market_price(mot_market_price *data, int oms_sock) {
     if (send(oms_sock, data, sizeof(mot_market_price), 0) == -1) {
         perror("[MOT_MARKET_PRICE] Failed to send to OMS socket");
     }
+}
+
+int validate_user_credentials(MYSQL *conn, const char *user_id, const char *user_pw) {
+    char query[256];
+    snprintf(query, sizeof(query),
+             "SELECT user_pw FROM users WHERE user_id = '%s'", user_id);
+
+    if (mysql_query(conn, query)) {
+        fprintf(stderr, "[validate_user_credentials] Query failed: %s\n", mysql_error(conn));
+        return SERVER_ERROR;
+    }
+
+    MYSQL_RES *result = mysql_store_result(conn);
+    if (!result) {
+        fprintf(stderr, "[validate_user_credentials] Failed to store result: %s\n", mysql_error(conn));
+        return SERVER_ERROR;
+    }
+
+    int status_code;
+    if (mysql_num_rows(result) == 0) { // no id
+        status_code = ID_NOT_FOUND;
+    } else {
+        MYSQL_ROW row = mysql_fetch_row(result);
+        if (row && strcmp(row[0], user_pw) == 0) { // success
+            status_code = LOGIN_SUCCESS;
+        } else { // not correct pw
+            status_code = PASSWORD_MISMATCH;
+        }
+    }
+
+    mysql_free_result(result);
+    return status_code;
+}
+
+void send_login_response(int oms_sock, int status_code) {
+    mot_login response;
+    response.hdr.tr_id = MOT_LOGIN;
+    response.hdr.length = sizeof(mot_login);
+    response.status_code = status_code;
+
+    if (send(oms_sock, &response, sizeof(response), 0) == -1) {
+        perror("[send_login_response] Failed to send response to OMS");
+    }
+    
+    printf("[send_login_response]: status code:%d\n", status_code);
+
 }

--- a/network/oms_network.h
+++ b/network/oms_network.h
@@ -1,6 +1,7 @@
 #ifndef OMS_HEADER_H
 #define OMS_HEADER_H
 
+#include <mysql/mysql.h>
 #include "common.h" // 공통 헤더 포함
 
 typedef struct {
@@ -32,11 +33,13 @@ typedef struct {
     current_market_price body[4]; // kmt_current_market_prices 구조체에서 current_market_price[4]
 } mot_market_price;
 
-void handle_oms(int oms_sock, int pipe_write, int pipe_read);
-void handle_omq_login(omq_login *data, int oms_sock);
+void handle_oms(MYSQL *conn, int oms_sock, int pipe_write, int pipe_read);
+void handle_omq_login(omq_login *data, int oms_sock, MYSQL *conn);
 void handle_omq_stocks(omq_stocks *data, int pipe_write);
 void handle_mot_stocks(mot_stocks *data, int oms_sock);
 void handle_omq_market_price(omq_market_price *data, int pipe_write);
 void handle_mot_market_price(mot_market_price *data, int oms_sock);
+void send_login_response(int oms_sock, int status_code);
+int validate_user_credentials(MYSQL *conn, const char *user_id, const char *user_pw);
 
 #endif

--- a/server/server.c
+++ b/server/server.c
@@ -13,7 +13,8 @@
 
 int main() {
     int krx_sock, oms_sock;
-    struct sockaddr_in krx_addr, oms_addr;
+    struct sockaddr_in krx_addr, oms_addr, client_addr;
+    socklen_t client_len;
 
     // krx, oms 프로세스 간 통신을 위한 pipe
     int pipe_krx_to_oms[2];
@@ -22,7 +23,7 @@ int main() {
         perror("Failed to create pipes");
         exit(EXIT_FAILURE);
     }
-    
+
     if ((krx_sock = socket(AF_INET, SOCK_STREAM, 0)) == -1) {
         perror("KRX socket creation failed");
         exit(EXIT_FAILURE);
@@ -40,8 +41,8 @@ int main() {
 
     pid_t krx_pid = fork();
     if (krx_pid == 0) {
-        close(pipe_krx_to_oms[0]); 
-        close(pipe_oms_to_krx[1]); 
+        close(pipe_krx_to_oms[0]);
+        close(pipe_oms_to_krx[1]);
         handle_krx(krx_sock, pipe_krx_to_oms[1], pipe_oms_to_krx[0]);
     } else if (krx_pid < 0) {
         perror("Fork for KRX failed");
@@ -55,34 +56,57 @@ int main() {
     }
 
     oms_addr.sin_family = AF_INET;
-    oms_addr.sin_port = htons(OMS_SERVER_PORT);
-    oms_addr.sin_addr.s_addr = inet_addr(OMS_SERVER_IP);
+    oms_addr.sin_port = htons(MCI_SERVER_PORT); // OMS 수신용 포트
+    oms_addr.sin_addr.s_addr = INADDR_ANY;
 
-    if (connect(oms_sock, (struct sockaddr *)&oms_addr, sizeof(oms_addr)) == -1) {
-        perror("OMS connection failed");
+    if (bind(oms_sock, (struct sockaddr *)&oms_addr, sizeof(oms_addr)) == -1) {
+        perror("Bind failed for OMS");
         close(oms_sock);
         exit(EXIT_FAILURE);
     }
 
-    pid_t oms_pid = fork();
-    if (oms_pid == 0) {
-        close(pipe_krx_to_oms[1]); 
-        close(pipe_oms_to_krx[0]); 
-        handle_oms(oms_sock, pipe_oms_to_krx[1], pipe_krx_to_oms[0]);
-    } else if (oms_pid < 0) {
-        perror("Fork for OMS failed");
+    if (listen(oms_sock, 5) == -1) {
+        perror("Listen failed for OMS");
         close(oms_sock);
         exit(EXIT_FAILURE);
+    }
+
+    printf("[OMS Server] Listening on port %d\n", MCI_SERVER_PORT);
+
+    while (1) {
+        client_len = sizeof(client_addr);
+        int client_sock = accept(oms_sock, (struct sockaddr *)&client_addr, &client_len);
+        if (client_sock == -1) {
+            perror("Accept failed");
+            continue;
+        }
+
+        printf("[OMS Server] Client connected: %s:%d\n",
+               inet_ntoa(client_addr.sin_addr),
+               ntohs(client_addr.sin_port));
+
+        pid_t oms_pid = fork();
+        if (oms_pid == 0) {
+            // 자식 프로세스: 클라이언트와 통신 처리
+            close(pipe_krx_to_oms[1]);
+            close(pipe_oms_to_krx[0]);
+            close(oms_sock);
+            handle_oms(client_sock, pipe_oms_to_krx[1], pipe_krx_to_oms[0]);
+            close(client_sock);
+            exit(0);
+        } else if (oms_pid < 0) {
+            perror("Fork for OMS failed");
+            close(client_sock);
+        }
+
+        close(client_sock);
     }
 
     close(pipe_krx_to_oms[0]);
     close(pipe_krx_to_oms[1]);
     close(pipe_oms_to_krx[0]);
     close(pipe_oms_to_krx[1]);
+    close(oms_sock);
 
-    int status;
-    while (wait(&status) > 0);
-
-    printf("All child processes terminated. Server exiting.\n");
     return 0;
 }


### PR DESCRIPTION
관련 이슈: #12

## OMS의 서버로 역할하도록 코드 수정
- OMS의 TCP 연결 요청에 응답하는 MCI 서버

## OMS-MCI 로그인 구현: mySQL 설치 필요
- 인증 로직 추가: `status_code` - `200`: 성공, `201`: no id, `202`: wrong pw

## 그 외
- 버퍼에 `struct` 크기 이상의 요청이 한번에 들어온 경우, 연속적으로 처리하도록 코드를 개선하였습니다.
- 이 과정에서 `hdr->length`를 참조하므로, 각 구조체 별 `hdr->length` 를 정확하게 정의해야 합니다.