### PR TITLE
feature: 거래내역 보기 기능 개발 및 서버 구조 개선

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -46,6 +46,8 @@ typedef struct {
 #define MOT_LOGIN 4
 #define MOT_STOCK_INFOS 5
 #define MOT_CURRENT_MARKET_PRICE 6
+#define OMQ_TX_HISTORY 12
+#define MOT_TX_HISTORY 13
 
 // KRX - MCI 관련
 #define KMT_STOCK_INFOS 7

--- a/mock/mock_oms_server.c
+++ b/mock/mock_oms_server.c
@@ -16,7 +16,7 @@ void send_login_request(int client_sock, const char *user_id, const char *user_p
     memset(&login, 0, sizeof(login));
 
     login.hdr.tr_id = 1; // omq_login
-    login.hdr.length = 108; // 길이
+    login.hdr.length = 108; // 길이 : 108
     strncpy(login.user_id, user_id, sizeof(login.user_id) - 1);
     strncpy(login.user_pw, user_pw, sizeof(login.user_pw) - 1);
 
@@ -51,7 +51,7 @@ void handle_server_response(int server_sock) {
 
             if (header->tr_id == MOT_LOGIN) {
                 mot_login *login = (mot_login *)(buffer + processed_bytes);
-                printf("[OMS Client] Login Response: tr_id: %d, status code: %d\n", login->hdr.tr_id, login->status_code);
+                printf("[OMS Client] Login Response: tr_id: %d, status code: %d, user_id: %s\n", login->hdr.tr_id, login->status_code, login->user_id);
             } else {
                 printf("[OMS Client] Received TR_ID: %d\n", header->tr_id);
             }
@@ -88,7 +88,7 @@ void start_oms_client() {
     printf("[OMS Client] Connected to MCI Server at %s:%d\n", MCI_SERVER_IP, MCI_SERVER_PORT);
 
     // TEST 성공
-    for(int i=0;i<100;i++){
+    for(int i=0;i<1;i++){
         send_login_request(client_sock, "hj", "1234"); // fail: 201
         send_login_request(client_sock, "jina", "123"); // fail: 202
         send_login_request(client_sock, "jina", "1234"); // success: 200

--- a/mock/mock_oms_server.c
+++ b/mock/mock_oms_server.c
@@ -9,7 +9,7 @@
 #include "env.h"
 #include "./network/oms_network.h"
 
-#define BUFFER_SIZE 1024
+#define BUFFER_SIZE 8192
 
 void send_login_request(int client_sock, const char *user_id, const char *user_pw) {
     omq_login login;
@@ -21,13 +21,41 @@ void send_login_request(int client_sock, const char *user_id, const char *user_p
     strncpy(login.user_pw, user_pw, sizeof(login.user_pw) - 1);
 
     if (send(client_sock, (void *)&login, sizeof(login), 0) == -1) {
-        perror("[OMS Client] Send failed");
+        perror("[OMS Client] Send login request failed");
         close(client_sock);
         exit(EXIT_FAILURE);
     }
 
     printf("[OMS Client] Sent login request: ID='%s', PW='%s'\n", user_id, user_pw);
 }
+
+void send_hisotry_request(int client_sock, const char *user_id){
+    omq_tx_history history;
+
+    history.hdr.tr_id = 12;
+    history.hdr.length = sizeof(omq_tx_history);
+    strncpy(history.user_id, user_id, sizeof(history.user_id) - 1);
+
+    if (send(client_sock, (void *)&history, sizeof(history), 0) == -1) {
+        perror("[OMS Client] Send history request failed");
+        close(client_sock);
+        exit(EXIT_FAILURE);
+    }
+}
+
+void print_tx(transaction *tx, int i){
+    printf("Transaction %d: ", i + 1);
+    // printf("  Stock Code: %s\n", tx->stock_code);
+    // printf("  Stock Name: %s\n", tx->stock_name);
+    // printf("  Transaction Code: %s\n", tx->tx_code);
+    // printf("  User ID: %s\n", tx->user_id);
+    // printf("  Order Type: %c\n", tx->order_type);
+    // printf("  Quantity: %d\n", tx->quantity);
+    printf("  Date/Time: %s\n", tx->datetime);
+    // printf("  Price: %d\n", tx->price);
+    // printf("  Status: %c\n", tx->status);
+}
+
 void handle_server_response(int server_sock) {
     char buffer[BUFFER_SIZE];
     size_t buffer_offset = 0;
@@ -44,7 +72,7 @@ void handle_server_response(int server_sock) {
         size_t processed_bytes = 0;
         while (processed_bytes + sizeof(hdr) <= buffer_offset) {
             hdr *header = (hdr *)(buffer + processed_bytes);
-
+            printf("header->length: %d\n",header->length);
             if (processed_bytes + header->length > buffer_offset) {
                 break;
             }
@@ -52,9 +80,22 @@ void handle_server_response(int server_sock) {
             if (header->tr_id == MOT_LOGIN) {
                 mot_login *login = (mot_login *)(buffer + processed_bytes);
                 printf("[OMS Client] Login Response: tr_id: %d, status code: %d, user_id: %s\n", login->hdr.tr_id, login->status_code, login->user_id);
-            } else {
-                printf("[OMS Client] Received TR_ID: %d\n", header->tr_id);
             }
+            else if(header->tr_id == MOT_TX_HISTORY){
+                mot_tx_history *history = (mot_tx_history *)(buffer + processed_bytes);
+                printf("[OMS Client] TX_history Response\n");
+
+                for (int i = 0; i < 50; i++) {
+                    transaction *tx = &history->tx_history[i];
+
+                    if (tx->stock_code[0] == '\0') {
+                        continue;
+                    }
+
+                    print_tx(tx, i);
+                }
+            }
+            else printf("[OMS Client] Received TR_ID: %d\n", header->tr_id);
 
             processed_bytes += header->length;
         }
@@ -89,13 +130,14 @@ void start_oms_client() {
 
     // TEST 성공
     for(int i=0;i<1;i++){
-        send_login_request(client_sock, "hj", "1234"); // fail: 201
-        send_login_request(client_sock, "jina", "123"); // fail: 202
+        // send_login_request(client_sock, "hj", "1234"); // fail: 201
+        // send_login_request(client_sock, "jina", "123"); // fail: 202
         send_login_request(client_sock, "jina", "1234"); // success: 200
+        send_hisotry_request(client_sock, "jina");
         if(i% 10 == 0) usleep(500000);
     }
     
-    printf("[OMS Client] Login request sent to MCI Server\n");
+    printf("[OMS Client] Request sent to MCI Server\n");
 
     // Handle server responses
     handle_server_response(client_sock);

--- a/network/oms_network.c
+++ b/network/oms_network.c
@@ -139,7 +139,7 @@ void handle_omq_login(omq_login *data, int oms_sock, MYSQL *conn) {
 
     int status_code = validate_user_credentials(conn, data->user_id, data->user_pw);
 
-    send_login_response(oms_sock, status_code);
+    send_login_response(oms_sock, data->user_id, status_code);
 }
 
 void handle_omq_stocks(omq_stocks *data, int pipe_write) {
@@ -206,10 +206,11 @@ int validate_user_credentials(MYSQL *conn, const char *user_id, const char *user
     return status_code;
 }
 
-void send_login_response(int oms_sock, int status_code) {
+void send_login_response(int oms_sock,char *user_id, int status_code) {
     mot_login response;
     response.hdr.tr_id = MOT_LOGIN;
-    response.hdr.length = sizeof(mot_login);
+    response.hdr.length = sizeof(mot_login); // // 62 + 2(패딩)
+    strncpy(response.user_id, user_id, sizeof(response.user_id) - 1);
     response.status_code = status_code;
 
     if (send(oms_sock, &response, sizeof(response), 0) == -1) {

--- a/network/oms_network.c
+++ b/network/oms_network.c
@@ -91,6 +91,9 @@ void handle_oms(MYSQL *conn, int oms_sock, int pipe_write, int pipe_read) {
                         case OMQ_LOGIN:
                             handle_omq_login((omq_login *)body, oms_sock, conn);
                             break;
+                        case OMQ_TX_HISTORY:
+                            handle_omq_tx_history((omq_tx_history *) body, oms_sock, conn);
+                            break;
                         case OMQ_STOCK_INFOS:
                             handle_omq_stocks((omq_stocks *)body, pipe_write);
                             break;
@@ -141,6 +144,72 @@ void handle_omq_login(omq_login *data, int oms_sock, MYSQL *conn) {
 
     send_login_response(oms_sock, data->user_id, status_code);
 }
+
+void handle_omq_tx_history(omq_tx_history *data, int oms_sock, MYSQL *conn) {
+    printf("[OMQ_TX_HISTORY] request id: %s\n", data->user_id);
+
+    char query[512];
+    snprintf(query, sizeof(query),
+             "SELECT stock_code, stock_name, transaction_code, user_id, order_type, quantity, "
+             "DATE_FORMAT(order_time, '%%Y%%m%%d%%H%%i%%s') AS datetime, price, status "
+             "FROM tx_history "
+             "WHERE user_id = '%s' "
+             "LIMIT 50", data->user_id);
+
+    if (mysql_query(conn, query)) {
+        fprintf(stderr, "[handle_omq_tx_history] Query failed: %s\n", mysql_error(conn));
+        return;
+    }
+
+    MYSQL_RES *result = mysql_store_result(conn);
+    if (!result) {
+        fprintf(stderr, "[handle_omq_tx_history] Failed to store result: %s\n", mysql_error(conn));
+        return;
+    }
+
+    mot_tx_history response = {0};
+    response.hdr.tr_id = 13;
+    
+    int row_count = 0;
+    MYSQL_ROW row;
+
+    while ((row = mysql_fetch_row(result)) && row_count < 50) {
+        strncpy(response.tx_history[row_count].stock_code, row[0], sizeof(response.tx_history[row_count].stock_code) - 1);
+        response.tx_history[row_count].stock_code[sizeof(response.tx_history[row_count].stock_code) - 1] = '\0';
+
+        strncpy(response.tx_history[row_count].stock_name, row[1], sizeof(response.tx_history[row_count].stock_name) - 1);
+        response.tx_history[row_count].stock_name[sizeof(response.tx_history[row_count].stock_name) - 1] = '\0';
+
+        strncpy(response.tx_history[row_count].tx_code, row[2], sizeof(response.tx_history[row_count].tx_code) - 1);
+        response.tx_history[row_count].tx_code[sizeof(response.tx_history[row_count].tx_code) - 1] = '\0';
+
+        strncpy(response.tx_history[row_count].user_id, row[3], sizeof(response.tx_history[row_count].user_id) - 1);
+        response.tx_history[row_count].user_id[sizeof(response.tx_history[row_count].user_id) - 1] = '\0';
+
+        response.tx_history[row_count].order_type = row[4][0];
+        response.tx_history[row_count].quantity = atoi(row[5]);
+
+        strncpy(response.tx_history[row_count].datetime, row[6], sizeof(response.tx_history[row_count].datetime) - 1);
+        response.tx_history[row_count].datetime[sizeof(response.tx_history[row_count].datetime) - 1] = '\0';
+
+        response.tx_history[row_count].price = atoi(row[7]);
+        response.tx_history[row_count].status = row[8][0];
+
+        row_count++;
+    }
+
+    response.hdr.length = sizeof(response);
+
+    // Send the response to the OMS
+    if (send(oms_sock, &response, sizeof(response), 0) == -1) {
+        perror("[handle_omq_tx_history] Failed to send response to OMS");
+    } else {
+        printf("[handle_omq_tx_history]: Sent %d transaction records to OMS\n", row_count);
+    }
+
+    mysql_free_result(result);
+}
+
 
 void handle_omq_stocks(omq_stocks *data, int pipe_write) {
     printf("[OMQ_STOCKS] Forwarding request to KRX process\n");

--- a/network/oms_network.h
+++ b/network/oms_network.h
@@ -34,6 +34,28 @@ typedef struct {
     current_market_price body[4]; // kmt_current_market_prices 구조체에서 current_market_price[4]
 } mot_market_price;
 
+typedef struct { // 거래 내역
+	char stock_code[6];
+	char stock_name[50];
+	char tx_code[6];
+	char user_id[50];
+	char order_type;
+	int quantity;
+	char datetime[15];	// 'YYYYMMDDHHMMSS'
+	int price;
+	char status; // 체결 여부
+} transaction;
+
+typedef struct {
+	hdr hdr;
+    char user_id[50];
+} omq_tx_history;
+
+typedef struct {
+	hdr hdr;
+	transaction tx_history[50]; // 오래된 tx부터 최대 50개까지 리턴
+} mot_tx_history;
+
 void handle_oms(MYSQL *conn, int oms_sock, int pipe_write, int pipe_read);
 void handle_omq_login(omq_login *data, int oms_sock, MYSQL *conn);
 void handle_omq_stocks(omq_stocks *data, int pipe_write);
@@ -42,5 +64,6 @@ void handle_omq_market_price(omq_market_price *data, int pipe_write);
 void handle_mot_market_price(mot_market_price *data, int oms_sock);
 void send_login_response(int oms_sock,char *user_id, int status_code);
 int validate_user_credentials(MYSQL *conn, const char *user_id, const char *user_pw);
+void handle_omq_tx_history(omq_tx_history *data, int oms_sock, MYSQL *conn);
 
 #endif

--- a/network/oms_network.h
+++ b/network/oms_network.h
@@ -12,6 +12,7 @@ typedef struct {
 
 typedef struct {
     hdr hdr;
+    char user_id[50];
     int status_code;
 } mot_login;
 
@@ -39,7 +40,7 @@ void handle_omq_stocks(omq_stocks *data, int pipe_write);
 void handle_mot_stocks(mot_stocks *data, int oms_sock);
 void handle_omq_market_price(omq_market_price *data, int pipe_write);
 void handle_mot_market_price(mot_market_price *data, int oms_sock);
-void send_login_response(int oms_sock, int status_code);
+void send_login_response(int oms_sock,char *user_id, int status_code);
 int validate_user_credentials(MYSQL *conn, const char *user_id, const char *user_pw);
 
 #endif


### PR DESCRIPTION
관련 이슈: #16 

# 거래내역 보기

- `user_id`에 해당하는 유저의 거래내역을 OMS 서버에 전송합니다.
- 구조체: `mot_tx_history`


- 클러스터링 인덱스를 `datetime`으로 설정하고 (user_id, datetime) 복합 인덱스를 구성하여, `ORDER BY` 절 없이 날짜 오름차순으로 거래내역(`transaction`구조체) 50개를 리턴합니다.

```
typedef struct { // 거래 내역
	char stock_code[6];
	char stock_name[50];
	char tx_code[6];
	char user_id[50];
	char order_type;
	int quantity;
	char datetime[15];	// 'YYYYMMDDHHMMSS'
	int price;
	char status; // 체결 여부
} transaction;

```

# 서버 구조 개선

- 이제 KRX 서버의 상태와 상관없이 MCI 서버가 OMS 서버와 통신할 수 있습니다.
- KRX 서버에게 5초마다 연결을 시도합니다.

- 이슈: KRX 서버와 연결 도중, KRX 서버가 MCI 클라이언트보다 먼저 종료될 때 다음 로그가 무한히 발생 중. 개선 필요.

<img width="336" alt="image" src="https://github.com/user-attachments/assets/f64a5800-6b34-4899-a6cc-5db22440cf22" />

